### PR TITLE
Introduce types for Colonies entitites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 build
 .vscode
 libcryptolib.so
+libcfslib.so

--- a/README.md
+++ b/README.md
@@ -230,13 +230,13 @@ The executor can now obtain the code, inject it, and then execute the specified 
 ```python
 assigned_process = colonies.assign(colonyname, 10, executor_prvkey)
 
-code_base64 = assigned_process["spec"]["env"]["code"]
+code_base64 = assigned_process.spec.env["code"]
 code_bytes2 = base64.b64decode(code_base64)
 code = code_bytes2.decode("ascii")
 
 exec(code)
 res = eval(funcname)(*tuple(args))
-colonies.close(assigned_process["processid"], [res], executor_prvkey)
+colonies.close(assigned_process.processid, [res], executor_prvkey)
 ```
 
 We can now create a distributed Python application where parts of the code runs on a remote executor.

--- a/__init__.py
+++ b/__init__.py
@@ -10,3 +10,4 @@ __credits__ = 'ri.se'
 
 import crypto
 import cfs
+import model

--- a/examples/colonies_monad.py
+++ b/examples/colonies_monad.py
@@ -30,7 +30,7 @@ class ColoniesMonad:
                  colonies: Colonies, 
                  colonyname, 
                  executor_prvkey): 
-        self.wf = Workflow(colonyname)
+        self.wf = Workflow(colonyname=colonyname)
         self.colonyname = colonyname
         self.executor_prvkey = executor_prvkey
         self.prev_func = None
@@ -39,12 +39,14 @@ class ColoniesMonad:
     def __ror__(self, other):
         pass
 
-    def __rshift__(self, f):  # bind function
+    def __rshift__(self, f: Function):  # bind function
         if self.prev_func is None:
-            self.wf.functionspecs.append(f.func_spec, nodename=f.name, dependencies=[])
+            self.wf.functionspecs.append(f.func_spec)
             self.prev_func = f.name
         else:
-            self.wf.functionspecs.append(f.func_spec, nodename=f.name, dependencies=[self.prev_func])
+            # HAX
+            f.func_spec.conditions.dependencies = [self.prev_func]
+            self.wf.functionspecs.append(f.func_spec)
             self.prev_func = f.name
         
         return self

--- a/examples/colonies_monad.py
+++ b/examples/colonies_monad.py
@@ -27,7 +27,7 @@ class Function:
 
 class ColoniesMonad:
     def __init__(self, 
-                 colonies, 
+                 colonies: Colonies, 
                  colonyname, 
                  executor_prvkey): 
         self.wf = Workflow(colonyname)
@@ -41,17 +41,17 @@ class ColoniesMonad:
 
     def __rshift__(self, f):  # bind function
         if self.prev_func is None:
-            self.wf.add(f.func_spec, nodename=f.name, dependencies=[])
+            self.wf.functionspecs.append(f.func_spec, nodename=f.name, dependencies=[])
             self.prev_func = f.name
         else:
-            self.wf.add(f.func_spec, nodename=f.name, dependencies=[self.prev_func])
+            self.wf.functionspecs.append(f.func_spec, nodename=f.name, dependencies=[self.prev_func])
             self.prev_func = f.name
         
         return self
 
     def unwrap(self):
-        processgraph = self.colonies.submit(self.wf, self.executor_prvkey)
-        last_process = self.colonies.find_process(self.prev_func, processgraph["processids"], self.executor_prvkey)
+        processgraph = self.colonies.submit_workflow(self.wf, self.executor_prvkey)
+        last_process = self.colonies.find_process(self.prev_func, processgraph.processids, self.executor_prvkey)
         process = self.colonies.wait(last_process, 100, self.executor_prvkey)
 
         if len(process.output)>0:

--- a/examples/colonies_monad.py
+++ b/examples/colonies_monad.py
@@ -54,6 +54,6 @@ class ColoniesMonad:
         last_process = self.colonies.find_process(self.prev_func, processgraph["processids"], self.executor_prvkey)
         process = self.colonies.wait(last_process, 100, self.executor_prvkey)
 
-        if len(process["out"])>0:
-            return process["out"][0]
+        if len(process.output)>0:
+            return process.output[0]
         return ""

--- a/examples/colonies_monad.py
+++ b/examples/colonies_monad.py
@@ -2,6 +2,8 @@ from pycolonies import Colonies
 from pycolonies import Workflow
 from pycolonies import func_spec 
 
+import copy
+
 class Function:
     def __init__(self,
                  func,
@@ -44,9 +46,9 @@ class ColoniesMonad:
             self.wf.functionspecs.append(f.func_spec)
             self.prev_func = f.name
         else:
-            # HAX
-            f.func_spec.conditions.dependencies = [self.prev_func]
-            self.wf.functionspecs.append(f.func_spec)
+            fs = copy.deepcopy(f.func_spec)
+            fs.conditions.dependencies = [self.prev_func]
+            self.wf.functionspecs.append(fs)
             self.prev_func = f.name
         
         return self

--- a/examples/cross_platform_demo.py
+++ b/examples/cross_platform_demo.py
@@ -1,56 +1,50 @@
-import os
 import random
-import pickle
-import matplotlib.pyplot as plt
-import random
-import json
 
-from termcolor import cprint 
-
-from pycolonies import Colonies
 from pycolonies import colonies_client
 from pycolonies import func_spec
-from pycolonies import Workflow
+from model import Workflow, FuncSpec, Conditions, Gpu
 
 colonies, colonyname, colony_prvkey, executorid, executor_prvkey = colonies_client()
 
-def gen_sleep(executorname):
-    return {
-    "conditions": {
-        "executortype": "container-executor",
-        "executornames": [
-            executorname
-        ],
-        "nodes": 1,
-        "processes-per-node": 1,
-        "mem": "500Mi",
-        "cpu": "1000m",
-        "gpu": {
-            "count": 0
+def gen_sleep(executorname, nodename, dependencies):
+    return FuncSpec (
+        conditions=Conditions(
+            executortype="container-executor",
+            executornames=[
+                executorname
+            ],
+            nodes=1,
+            processes_per_node=1,
+            mem="500Mi",
+            cpu="1000m",
+            gpu=Gpu(
+                count=0
+            ),
+            walltime=60,
+            dependencies=dependencies
+        ),
+        funcname="execute",
+        kwargs={
+            "cmd": "sleep 8",
+            "docker-image": "ubuntu:20.04"
         },
-        "walltime": 60
-    },
-    "funcname": "execute",
-    "kwargs": {
-        "cmd": "sleep 8",
-        "docker-image": "ubuntu:20.04"
-    },
-    "maxexectime": 55,
-    "maxretries": 3
-}
+        maxexectime=55,
+        maxretries=3,
+        nodename=nodename
+    )
 
 
 wf = Workflow(colonyname)
-wf.add(gen_sleep("icekube"), nodename="ice-0", dependencies=[])
-wf.add(gen_sleep("lumi-std"), nodename="lumi-0", dependencies=["ice-0"])
-wf.add(gen_sleep("lumi-std"), nodename="lumi-1", dependencies=["ice-0"])
-wf.add(gen_sleep("lumi-std"), nodename="lumi-2", dependencies=["ice-0"])
-wf.add(gen_sleep("lumi-std"), nodename="lumi-3", dependencies=["ice-0"])
-wf.add(gen_sleep("lumi-std"), nodename="lumi-4", dependencies=["ice-0"])
-wf.add(gen_sleep("lumi-std"), nodename="lumi-5", dependencies=["ice-0"])
-wf.add(gen_sleep("lumi-std"), nodename="lumi-6", dependencies=["ice-0"])
-wf.add(gen_sleep("lumi-std "), nodename="lumi-7", dependencies=["ice-0"])
-wf.add(gen_sleep("leonardo-booster"), nodename="leonardo-0", dependencies=["lumi-0", "lumi-1", "lumi-2", "lumi-3", "lumi-4", "lumi-5", "lumi-6", "lumi-7"])
+wf.functionspecs.append(gen_sleep("icekube", nodename="ice-0", dependencies=[]))
+wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-0", dependencies=["ice-0"]))
+wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-1", dependencies=["ice-0"]))
+wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-2", dependencies=["ice-0"]))
+wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-3", dependencies=["ice-0"]))
+wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-4", dependencies=["ice-0"]))
+wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-5", dependencies=["ice-0"]))
+wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-6", dependencies=["ice-0"]))
+wf.functionspecs.append(gen_sleep("lumi-std ", nodename="lumi-7", dependencies=["ice-0"]))
+wf.functionspecs.append(gen_sleep("leonardo-booster", nodename="leonardo-0", dependencies=["lumi-0", "lumi-1", "lumi-2", "lumi-3", "lumi-4", "lumi-5", "lumi-6", "lumi-7"]))
 
-wf.add(gen_sleep("icekube"), nodename="ice-1", dependencies=["leonardo-0"])
-colonies.submit(wf, executor_prvkey)
+wf.functionspecs.append(gen_sleep("icekube", nodename="ice-1", dependencies=["leonardo-0"]))
+colonies.submit_workflow(wf, executor_prvkey)

--- a/examples/cross_platform_demo.py
+++ b/examples/cross_platform_demo.py
@@ -34,7 +34,7 @@ def gen_sleep(executorname, nodename, dependencies):
     )
 
 
-wf = Workflow(colonyname)
+wf = Workflow(colonyname=colonyname)
 wf.functionspecs.append(gen_sleep("icekube", nodename="ice-0", dependencies=[]))
 wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-0", dependencies=["ice-0"]))
 wf.functionspecs.append(gen_sleep("lumi-std", nodename="lumi-1", dependencies=["ice-0"]))

--- a/examples/des_executor.py
+++ b/examples/des_executor.py
@@ -48,22 +48,22 @@ class PythonExecutor:
         while (True):
             try:
                 process = self.colonies.assign(self.colonyname, 3, self.executor_prvkey)
-                print("Process", process["processid"], "is assigned to executor")
+                print("Process", process.processid, "is assigned to executor")
                 
-                self.colonies.add_log(process["processid"], "Calculating NDVI\n", self.executor_prvkey)
+                self.colonies.add_log(process.processid, "Calculating NDVI\n", self.executor_prvkey)
 
-                if not ('spec' in process and 'kwargs' in process['spec']):
+                if process.spec is None or len(process.spec.kwargs) == 0:
                     print("invalid process")
                     continue
 
-                polygon = process["spec"]["kwargs"]["polygon"]
-                product = process["spec"]["kwargs"]["product"]
-                time = process["spec"]["kwargs"]["time"]
+                polygon = process.spec.kwargs["polygon"]
+                product = process.spec.kwargs["product"]
+                time = process.spec.kwargs["time"]
 
                 ndvi_serie = calc_ndvi(polygon, product, time)
 
-                if process["spec"]["funcname"] == "calc_ts":
-                    self.colonies.close(process["processid"], ndvi_serie, self.executor_prvkey)
+                if process.spec.funcname == "calc_ts":
+                    self.colonies.close(process.processid, ndvi_serie, self.executor_prvkey)
             except Exception as err:
                 pass 
 

--- a/examples/echo_executor.py
+++ b/examples/echo_executor.py
@@ -47,17 +47,17 @@ class PythonExecutor:
         while (True):
             try:
                 process = self.colonies.assign(self.colonyname, 10, self.executor_prvkey)
-                print("Process", process["processid"], "is assigned to executor")
-                if process["spec"]["funcname"] == "echo":
+                print("Process", process.processid, "is assigned to executor")
+                if process.spec.funcname == "echo":
                     # if "in" is defined, it is the output of the parent process,
                     # use the output from parent process instead of args
-                    if len(process["in"])>0:
-                        args = process["in"]
+                    if len(process.input)>0:
+                        args = process.input
                     else:
-                        args = process["spec"]["args"]
+                        args = process.spec.args
 
                     # just set output to input value 
-                    self.colonies.close(process["processid"], [args[0]], self.executor_prvkey)
+                    self.colonies.close(process.processid, [args[0]], self.executor_prvkey)
             except Exception as err:
                 print(err)
                 pass

--- a/examples/helloworld_executor.py
+++ b/examples/helloworld_executor.py
@@ -44,10 +44,10 @@ class PythonExecutor:
         while (True):
             try:
                 process = self.colonies.assign(self.colonyname, 10, self.executor_prvkey)
-                print("Process", process["processid"], "is assigned to executor")
-                self.colonies.add_log(process["processid"], "Hello from executor\n", self.executor_prvkey)
-                if process["spec"]["funcname"] == "helloworld":
-                    self.colonies.close(process["processid"], ["helloworld"], self.executor_prvkey)
+                print("Process", process.processid, "is assigned to executor")
+                self.colonies.add_log(process.processid, "Hello from executor\n", self.executor_prvkey)
+                if process.spec.funcname == "helloworld":
+                    self.colonies.close(process.processid, ["helloworld"], self.executor_prvkey)
             except Exception as err:
                 print(err)
                 pass

--- a/examples/kwargs_executor.py
+++ b/examples/kwargs_executor.py
@@ -38,13 +38,13 @@ class PythonExecutor:
         while (True):
             try:
                 process = self.colonies.assign(self.colonyname, 10, self.executor_prvkey)
-                print("Process", process["processid"], "is assigned to executor")
-                if process["spec"]["funcname"] == "test":
-                    kwargs = process["spec"]["kwargs"]
+                print("Process", process.processid, "is assigned to executor")
+                if process.spec.funcname == "test":
+                    kwargs = process.spec.kwargs
                     print(kwargs["arg_kw_1"])
 
                     # just set output to input value 
-                    self.colonies.close(process["processid"], [""], self.executor_prvkey)
+                    self.colonies.close(process.processid, [""], self.executor_prvkey)
             except Exception as err:
                 print(err)
                 pass

--- a/examples/python_executor.py
+++ b/examples/python_executor.py
@@ -71,7 +71,7 @@ class PythonExecutor:
                 try:
                     # if "in" is defined, it is the output of the parent process,
                     # use the output from parent process instead of args
-                    print(assigned_process.model_dump_json())
+                    
                     if assigned_process.input is not None and len(assigned_process.input)>0:
                         args = assigned_process.input
                     else:

--- a/examples/python_executor.py
+++ b/examples/python_executor.py
@@ -47,10 +47,10 @@ class PythonExecutor:
                 # an exception will be raised if no processes can be assigned, and we will restart start the while loop
                 assigned_process = self.colonies.assign(self.colonyname, 10, self.executor_prvkey)
                 print()
-                print("Process", assigned_process["processid"], "is assigned to Executor")
+                print("Process", assigned_process.processid, "is assigned to Executor")
 
                 # ok, executor was assigned a process, extract the function code to run
-                code_base64 = assigned_process["spec"]["env"]["code"]
+                code_base64 = assigned_process.spec.env["code"]
                 code_bytes2 = base64.b64decode(code_base64)
                 code = code_bytes2.decode("ascii")
 
@@ -58,8 +58,8 @@ class PythonExecutor:
                 exec(code)
 
                 # extract args and call the function code we just injected
-                funcspec = assigned_process["spec"]
-                funcname = funcspec["funcname"]
+                funcspec = assigned_process.spec
+                funcname = funcspec.funcname
                 try:
                     self.colonies.add_function(self.colonyname, 
                                              self.executorname, 
@@ -71,14 +71,15 @@ class PythonExecutor:
                 try:
                     # if "in" is defined, it is the output of the parent process,
                     # use the output from parent process instead of args
-                    if assigned_process["in"] is not None and len(assigned_process["in"])>0:
-                        args = assigned_process["in"] 
+                    print(assigned_process.model_dump_json())
+                    if assigned_process.input is not None and len(assigned_process.input)>0:
+                        args = assigned_process.input
                     else:
-                        args = funcspec["args"]
+                        args = funcspec.args
                 except Exception as err:
                     print(err)
 
-                print("Executing:", funcspec["funcname"])
+                print("Executing:", funcspec.funcname)
 
                 # call the injected function
                 try:
@@ -86,8 +87,9 @@ class PythonExecutor:
                            "colonyname": self.colonyname,
                            "executorid": self.executorid,
                            "executor_prvkey": self.executor_prvkey}
-  
+                      
                     res = eval(funcname)(*tuple(args), ctx=ctx)
+
                     if res is not None:
                         if type(res) is tuple:
                             res_arr = list(res)
@@ -97,13 +99,12 @@ class PythonExecutor:
                         res_arr = []
                 except Exception as err:
                     print("Failed to execute function:", err)
-                    print(code)
-                    self.colonies.fail(assigned_process["processid"], ["Failed to execute function"], self.executor_prvkey)
+                    self.colonies.fail(assigned_process.processid, ["Failed to execute function"], self.executor_prvkey)
                     continue
 
                 print("done")
                 # close the process as successful
-                self.colonies.close(assigned_process["processid"], res_arr, self.executor_prvkey)
+                self.colonies.close(assigned_process.processid, res_arr, self.executor_prvkey)
             except ColoniesConnectionError as err:
                 print(err)
                 sys.exit(-1)

--- a/examples/submit_echo.py
+++ b/examples/submit_echo.py
@@ -12,7 +12,8 @@ f = func_spec(func="echo",
               maxretries=3,
               maxwaittime=100)
 
-process = colonies.submit(f, prvkey)
-print("Process", process["processid"], "submitted")
+process = colonies.submit_func_spec(f, prvkey)
+print("Process", process.processid, "submitted")
 process = colonies.wait(process, 100, prvkey)
 print(process.output[0])
+

--- a/examples/submit_echo.py
+++ b/examples/submit_echo.py
@@ -15,4 +15,4 @@ f = func_spec(func="echo",
 process = colonies.submit(f, prvkey)
 print("Process", process["processid"], "submitted")
 process = colonies.wait(process, 100, prvkey)
-print(process["out"][0])
+print(process.output[0])

--- a/examples/submit_helloworld.py
+++ b/examples/submit_helloworld.py
@@ -13,8 +13,8 @@ func_spec = func_spec(func="helloworld",
                       maxwaittime=100)
 
 # submit the function spec to the colonies server
-process = colonies.submit(func_spec, prvkey)
-print("Process", process["processid"], "submitted")
+process = colonies.submit_func_spec(func_spec, prvkey)
+print("Process", process.processid, "submitted")
 
 # wait for the process to be executed
 process = colonies.wait(process, 10, prvkey)

--- a/examples/submit_helloworld.py
+++ b/examples/submit_helloworld.py
@@ -18,4 +18,4 @@ print("Process", process["processid"], "submitted")
 
 # wait for the process to be executed
 process = colonies.wait(process, 10, prvkey)
-print(process["out"][0])
+print(process.output[0])

--- a/examples/submit_helloworld_wf.py
+++ b/examples/submit_helloworld_wf.py
@@ -1,11 +1,10 @@
 from pycolonies import colonies_client
 from pycolonies import func_spec
 from pycolonies import Workflow
-import copy
 
 colonies, colonyname, colony_prvkey, executorid, executor_prvkey = colonies_client()
 
-func_spec = func_spec(func="helloworld", 
+fs1 = func_spec(func="hello1", 
                       args=[], 
                       colonyname=colonyname, 
                       executortype="helloworld-executor",
@@ -13,9 +12,25 @@ func_spec = func_spec(func="helloworld",
                       maxretries=3,
                       maxwaittime=100)
 
-wf = Workflow(colonyname)
-wf.add(func_spec, nodename="hello1", dependencies=[])
-wf.add(copy.deepcopy(func_spec), nodename="hello2", dependencies=["hello1"])
-wf.add(copy.deepcopy(func_spec), nodename="hello3", dependencies=["hello1"])
+fs2 = func_spec(func="hello2", 
+                      args=[], 
+                      colonyname=colonyname, 
+                      executortype="helloworld-executor",
+                      maxexectime=10,
+                      maxretries=3,
+                      maxwaittime=100)
 
-colonies.submit(wf, executor_prvkey)
+fs3 = func_spec(func="hello3", 
+                      args=[], 
+                      colonyname=colonyname, 
+                      executortype="helloworld-executor",
+                      maxexectime=10,
+                      maxretries=3,
+                      maxwaittime=100)
+
+fs2.conditions.dependencies.append("hello1")
+fs3.conditions.dependencies.append("hello2")
+
+wf = Workflow(colonyname=colonyname, functionspecs=[fs1, fs2, fs3])
+
+colonies.submit_workflow(wf, executor_prvkey)

--- a/examples/submit_kwargs.py
+++ b/examples/submit_kwargs.py
@@ -16,7 +16,7 @@ f = func_spec(func="test",
               maxretries=3,
               maxwaittime=100)
 
-process = colonies.submit(f, prvkey)
-print("Process", process["processid"], "submitted")
+process = colonies.submit_func_spec(f, prvkey)
+print("Process", process.processid, "submitted")
 process = colonies.wait(process, 100, prvkey)
 print(process.output[0])

--- a/examples/submit_kwargs.py
+++ b/examples/submit_kwargs.py
@@ -19,4 +19,4 @@ f = func_spec(func="test",
 process = colonies.submit(f, prvkey)
 print("Process", process["processid"], "submitted")
 process = colonies.wait(process, 100, prvkey)
-print(process["out"][0])
+print(process.output[0])

--- a/examples/submit_python.py
+++ b/examples/submit_python.py
@@ -16,8 +16,8 @@ func_spec = func_spec(func=sum_nums,
                       maxwaittime=100)
 
 # submit the function spec to the colonies server
-process = colonies.submit(func_spec, prvkey)
-print("Process", process["processid"], "submitted")
+process = colonies.submit_func_spec(func_spec, prvkey)
+print("Process", process.processid, "submitted")
 
 # wait for the process to be executed
 process = colonies.wait(process, 100, prvkey)

--- a/examples/submit_python.py
+++ b/examples/submit_python.py
@@ -21,4 +21,4 @@ print("Process", process["processid"], "submitted")
 
 # wait for the process to be executed
 process = colonies.wait(process, 100, prvkey)
-print(process["out"][0])
+print(process.output[0])

--- a/examples/workflow_example1.py
+++ b/examples/workflow_example1.py
@@ -10,8 +10,8 @@ def gen_nums(ctx={}):
 def sum_nums(n1, n2, ctx={}):
     return n1 + n2 
 
-wf = Workflow(colonyname)
-f = func_spec(func=gen_nums, 
+wf = Workflow(colonyname=colonyname)
+f = func_spec(func=gen_nums,
               args=[], 
               colonyname=colonyname, 
               executortype="python-executor",
@@ -19,7 +19,8 @@ f = func_spec(func=gen_nums,
               maxexectime=100,
               maxretries=3,
               maxwaittime=100)
-wf.add(f, nodename="gen_nums", dependencies=[])
+
+wf.functionspecs.append(f)
 
 f = func_spec(func=sum_nums, 
               args=[], 
@@ -28,13 +29,16 @@ f = func_spec(func=sum_nums,
               priority=200,
               maxexectime=100,
               maxretries=3,
-              maxwaittime=100) 
-wf.add(f, nodename="sum_nums", dependencies=["gen_nums"])
+              maxwaittime=100)
 
-processgraph = colonies.submit(wf, prvkey)
-print("Workflow", processgraph["processgraphid"], "submitted")
+f.conditions.dependencies.append("gen_nums")
+
+wf.functionspecs.append(f)
+
+processgraph = colonies.submit_workflow(wf, prvkey)
+print("Workflow", processgraph.processgraphid, "submitted")
 
 # wait for the sum_list process
-process = colonies.find_process("sum_nums", processgraph["processids"], prvkey)
+process = colonies.find_process("sum_nums", processgraph.processids, prvkey)
 process = colonies.wait(process, 100, prvkey)
 print(process.output[0])

--- a/examples/workflow_example1.py
+++ b/examples/workflow_example1.py
@@ -37,4 +37,4 @@ print("Workflow", processgraph["processgraphid"], "submitted")
 # wait for the sum_list process
 process = colonies.find_process("sum_nums", processgraph["processids"], prvkey)
 process = colonies.wait(process, 100, prvkey)
-print(process["out"][0])
+print(process.output[0])

--- a/examples/workflow_example2.py
+++ b/examples/workflow_example2.py
@@ -13,7 +13,7 @@ def reduce(*nums, ctx={}):
         total += n
     return total 
 
-wf = Workflow(colonyname)
+wf = Workflow(colonyname=colonyname)
 f = func_spec(func=gen_nums, 
               args=[], 
               colonyname=colonyname, 
@@ -22,7 +22,9 @@ f = func_spec(func=gen_nums,
               maxexectime=100,
               maxretries=3,
               maxwaittime=100)
-wf.add(f, nodename="gen_nums1", dependencies=[])
+
+f.nodename = "gen_nums1"
+wf.functionspecs.append(f)
 
 f = func_spec(func=gen_nums, 
               args=[], 
@@ -32,7 +34,9 @@ f = func_spec(func=gen_nums,
               maxexectime=100,
               maxretries=3,
               maxwaittime=100)
-wf.add(f, nodename="gen_nums2", dependencies=[])
+
+f.nodename = "gen_nums2"
+wf.functionspecs.append(f)
 
 func_spec = func_spec(func=reduce, 
                              args=[], 
@@ -42,12 +46,14 @@ func_spec = func_spec(func=reduce,
                              maxexectime=100,
                              maxretries=3,
                              maxwaittime=100) 
-wf.add(func_spec, nodename="reduce", dependencies=["gen_nums1", "gen_nums2"])
 
-processgraph = colonies.submit(wf, prvkey)
-print("Workflow", processgraph["processgraphid"], "submitted")
+func_spec.conditions.dependencies = ["gen_nums1", "gen_nums2"]
+wf.functionspecs.append(func_spec)
+
+processgraph = colonies.submit_workflow(wf, prvkey)
+print("Workflow", processgraph.processgraphid, "submitted")
 
 # wait for the sum_list process
-process = colonies.find_process("reduce", processgraph["processids"], prvkey)
+process = colonies.find_process("reduce", processgraph.processids, prvkey)
 process = colonies.wait(process, 100, prvkey)
 print(process.output[0])

--- a/examples/workflow_example2.py
+++ b/examples/workflow_example2.py
@@ -50,4 +50,4 @@ print("Workflow", processgraph["processgraphid"], "submitted")
 # wait for the sum_list process
 process = colonies.find_process("reduce", processgraph["processids"], prvkey)
 process = colonies.wait(process, 100, prvkey)
-print(process["out"][0])
+print(process.output[0])

--- a/examples/workflow_example3.py
+++ b/examples/workflow_example3.py
@@ -66,4 +66,4 @@ print("Workflow", processgraph["processgraphid"], "submitted")
 # wait for the sum_list process
 process = colonies.find_process("reduce", processgraph["processids"], prvkey)
 process = colonies.wait(process, 1000, prvkey)
-print(process["out"])
+print(process.output[0])

--- a/model.py
+++ b/model.py
@@ -81,6 +81,22 @@ class Workflow(BaseModel):
     colonyname: str
     functionspecs: List[FuncSpec] = []
 
+class Position(BaseModel):
+    x: int
+    y: int
+
+class ProcessNode(BaseModel):
+    id: str
+    data: Dict[str, str] = {}
+    position: Position
+    type: str
+    style: Dict[str, str] = {}
+
+class ProcessEdge(BaseModel):
+    id: str
+    source: str
+    target: str
+    animated: bool
 
 class ProcessGraph(BaseModel):
     processgraphid: str
@@ -93,6 +109,6 @@ class ProcessGraph(BaseModel):
     starttime: datetime
     endtime: datetime
     processids: List[str]
-    # TODO: set proper types for these
-    nodes: List[str]
-    edges: List[str]
+    nodes: List[ProcessNode]
+    edges: List[ProcessEdge]
+

--- a/model.py
+++ b/model.py
@@ -36,7 +36,7 @@ class FuncSpec(BaseModel):
     nodename: str = ""
     funcname: str = ""
     args: List[str] = []
-    kwargs: Dict[str, str] = {}
+    kwargs: Dict[str, str] | None = {}
     priority: int = 0
     maxwaittime: int = 0
     maxexectime: int = 0

--- a/model.py
+++ b/model.py
@@ -72,8 +72,8 @@ class Process(BaseModel):
     parents: List[str]
     children: List[str]
     processgraphid: str
-    input: List[str | int] | None = Field(alias="in")
-    output: List[str | int] | None = Field(alias="out")
+    input: List[str | int | float] | None = Field(alias="in")
+    output: List[str | int | float] | None = Field(alias="out")
     errors: List[str]
 
 

--- a/model.py
+++ b/model.py
@@ -46,11 +46,13 @@ class FuncSpec(BaseModel):
     fs: Fs | None = Fs(mount="", snapshots=None, dirs=None)
     env: Dict[str, str] = {}
 
+
 class Attribute(BaseModel):
     key: str
     value: str
     targetid: str
     attributetype: int
+
 
 class Process(BaseModel):
     processid: str
@@ -81,9 +83,11 @@ class Workflow(BaseModel):
     colonyname: str
     functionspecs: List[FuncSpec] = []
 
+
 class Position(BaseModel):
     x: int
     y: int
+
 
 class ProcessNode(BaseModel):
     id: str
@@ -92,11 +96,13 @@ class ProcessNode(BaseModel):
     type: str
     style: Dict[str, str] = {}
 
+
 class ProcessEdge(BaseModel):
     id: str
     source: str
     target: str
     animated: bool
+
 
 class ProcessGraph(BaseModel):
     processgraphid: str
@@ -111,4 +117,3 @@ class ProcessGraph(BaseModel):
     processids: List[str]
     nodes: List[ProcessNode]
     edges: List[ProcessEdge]
-

--- a/model.py
+++ b/model.py
@@ -1,0 +1,98 @@
+from datetime import datetime
+
+from typing import List, Dict, Optional
+from pydantic import BaseModel, Field
+
+
+class Gpu(BaseModel):
+    name: str = ""
+    mem: str = ""
+    count: int = 0
+    nodecount: int = 0
+
+
+class Conditions(BaseModel):
+    colonyname: str
+    executornames: List[str] | None = None
+    executortype: str
+    dependencies: List[str] = []
+    nodes: int = 0
+    cpu: str = ""
+    processes: int = 0
+    processes_per_node: int = Field(alias="processes-per-node", default=0)
+    mem: str = ""
+    storage: str = ""
+    gpu: Gpu | None = Gpu()
+    walltime: int = 0
+
+
+class Fs(BaseModel):
+    mount: str
+    snapshots: List[str] | None
+    dirs: List[str] | None
+
+
+class Spec(BaseModel):
+    nodename: str = ""
+    funcname: str = ""
+    args: List[str] = []
+    kwargs: Dict[str, str] = {}
+    priority: int = 0
+    maxwaittime: int = 0
+    maxexectime: int = 0
+    maxretries: int = 0
+    conditions: Conditions
+    label: str = ""
+    fs: Fs = Fs(mount="", snapshots=None, dirs=None)
+    env: Dict[str, str] = {}
+
+class Attribute(BaseModel):
+    key: str
+    value: str
+    targetid: str
+    attributetype: int
+
+class Process(BaseModel):
+    processid: str
+    initiatorid: str
+    initiatorname: str
+    assignedexecutorid: str
+    isassigned: bool
+    state: int
+    prioritytime: int
+    submissiontime: datetime
+    starttime: datetime
+    endtime: datetime
+    waitdeadline: datetime
+    execdeadline: datetime
+    retries: int
+    attributes: List[Attribute] | None
+    spec: Spec
+    waitforparents: bool = False
+    parents: List[str]
+    children: List[str]
+    processgraphid: str
+    input: List[str] = Field(alias="in")
+    output: List[str] = Field(alias="out")
+    errors: List[str]
+
+
+class Workflow(BaseModel):
+    colonyname: str
+    functionspecs: List[Spec]
+
+
+class ProcessGraph(BaseModel):
+    processgraphid: str
+    initiatorid: str
+    initiatorname: str
+    colonyname: str
+    rootprocessids: List[str]
+    state: int
+    submissiontime: datetime
+    starttime: datetime
+    endtime: datetime
+    processids: List[str]
+    # TODO: set proper types for these
+    nodes: List[str]
+    edges: List[str]

--- a/model.py
+++ b/model.py
@@ -72,8 +72,8 @@ class Process(BaseModel):
     parents: List[str]
     children: List[str]
     processgraphid: str
-    input: List[str | int] = Field(alias="in")
-    output: List[str | int] = Field(alias="out")
+    input: List[str | int] | None = Field(alias="in")
+    output: List[str | int] | None = Field(alias="out")
     errors: List[str]
 
 

--- a/model.py
+++ b/model.py
@@ -32,7 +32,7 @@ class Fs(BaseModel):
     dirs: List[str] | None
 
 
-class Spec(BaseModel):
+class FuncSpec(BaseModel):
     nodename: str = ""
     funcname: str = ""
     args: List[str] = []
@@ -43,7 +43,7 @@ class Spec(BaseModel):
     maxretries: int = 0
     conditions: Conditions
     label: str = ""
-    fs: Fs = Fs(mount="", snapshots=None, dirs=None)
+    fs: Fs | None = Fs(mount="", snapshots=None, dirs=None)
     env: Dict[str, str] = {}
 
 class Attribute(BaseModel):
@@ -67,7 +67,7 @@ class Process(BaseModel):
     execdeadline: datetime
     retries: int
     attributes: List[Attribute] | None
-    spec: Spec
+    spec: FuncSpec
     waitforparents: bool = False
     parents: List[str]
     children: List[str]
@@ -79,7 +79,7 @@ class Process(BaseModel):
 
 class Workflow(BaseModel):
     colonyname: str
-    functionspecs: List[Spec]
+    functionspecs: List[FuncSpec]
 
 
 class ProcessGraph(BaseModel):

--- a/model.py
+++ b/model.py
@@ -12,7 +12,7 @@ class Gpu(BaseModel):
 
 
 class Conditions(BaseModel):
-    colonyname: str
+    colonyname: str = ""
     executornames: List[str] | None = None
     executortype: str
     dependencies: List[str] = []
@@ -35,7 +35,7 @@ class Fs(BaseModel):
 class FuncSpec(BaseModel):
     nodename: str = ""
     funcname: str = ""
-    args: List[str] = []
+    args: List[str | int] = []
     kwargs: Dict[str, str] | None = {}
     priority: int = 0
     maxwaittime: int = 0
@@ -72,14 +72,14 @@ class Process(BaseModel):
     parents: List[str]
     children: List[str]
     processgraphid: str
-    input: List[str] = Field(alias="in")
-    output: List[str] = Field(alias="out")
+    input: List[str | int] = Field(alias="in")
+    output: List[str | int] = Field(alias="out")
     errors: List[str]
 
 
 class Workflow(BaseModel):
     colonyname: str
-    functionspecs: List[FuncSpec]
+    functionspecs: List[FuncSpec] = []
 
 
 class ProcessGraph(BaseModel):

--- a/pycolonies.py
+++ b/pycolonies.py
@@ -371,7 +371,7 @@ class Colonies:
     def find_process(self, nodename, processids, prvkey):
         for processid in processids:
             process = self.get_process(processid, prvkey)
-            if process["spec"]["nodename"] == nodename:
+            if process.spec.nodename == nodename:
                 return process
         return None
     

--- a/pycolonies.py
+++ b/pycolonies.py
@@ -339,7 +339,8 @@ class Colonies:
             "msgtype": "getprocessgraphmsg",
             "processgraphid": processgraphid
         }
-        return self.__rpc(msg, prvkey)
+        graph = self.__rpc(msg, prvkey)
+        return ProcessGraph(**graph)
     
     def add_function(self, colonyname, executorname, funcname, prvkey):
         func = {}

--- a/pycolonies.py
+++ b/pycolonies.py
@@ -376,15 +376,15 @@ class Colonies:
                 return process
         return None
     
-    def add_child(self, processgraphid, parentprocessid, childprocessid, funcspec, nodename, insert, prvkey):
-        funcspec["nodename"] = nodename
+    def add_child(self, processgraphid, parentprocessid, childprocessid, funcspec: FuncSpec, nodename, insert, prvkey):
+        funcspec.nodename = nodename
         msg = {
             "msgtype": "addchildmsg",
             "processgraphid": processgraphid,
             "parentprocessid": parentprocessid,
             "childprocessid": childprocessid,
             "insert": insert,
-            "spec": funcspec
+            "spec": funcspec.model_dump()
         }
         return self.__rpc(msg, prvkey)
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.27.1
 websocket-client>=1.3.1
+pydantic>=2.6.4

--- a/test/colonies_test.py
+++ b/test/colonies_test.py
@@ -6,7 +6,7 @@ import random
 sys.path.append(".")
 from crypto import Crypto
 from pycolonies import Colonies
-from model import Spec, Conditions, Workflow
+from model import FuncSpec, Conditions, Workflow
 import os
 
 
@@ -52,7 +52,7 @@ class TestColonies(unittest.TestCase):
         )
 
     def submit_test_funcspec(self, colonyname, executor_prvkey):
-        spec = Spec(
+        spec = FuncSpec(
             conditions=Conditions(
                 colonyname=colonyname, executortype="test-executor-type"
             ),
@@ -166,7 +166,7 @@ class TestColonies(unittest.TestCase):
         workflow = Workflow(
             colonyname=colonyname,
             functionspecs=[
-                Spec(
+                FuncSpec(
                     nodename="node1",
                     conditions=Conditions(
                         colonyname=colonyname, executortype="test-executor-type"
@@ -175,7 +175,7 @@ class TestColonies(unittest.TestCase):
                     maxexectime=-1,
                     maxretries=3,
                 ),
-                Spec(
+                FuncSpec(
                     nodename="node2",
                     conditions=Conditions(
                         colonyname=colonyname,
@@ -476,7 +476,7 @@ class TestColonies(unittest.TestCase):
         )
         self.colonies.approve_executor(colonyname, executorname, colony_prvkey)
 
-        func_spec = Spec(
+        func_spec = FuncSpec(
             conditions=Conditions(
                 colonyname=colonyname, executortype="test-executor-type"
             ),

--- a/test/func_spec_test.py
+++ b/test/func_spec_test.py
@@ -11,7 +11,7 @@ class TestFuncSpec(unittest.TestCase):
             "two": "2"
         }
 
-        fs = func_spec(
+        spec = func_spec(
             func="sum_nums",
             args=["helloworld"],
             colonyname="colonyname",
@@ -24,17 +24,17 @@ class TestFuncSpec(unittest.TestCase):
             kwargs=kwargs
         )
 
-        self.assertEqual(fs["nodename"], "sum_nums")
-        self.assertEqual(fs["funcname"], "sum_nums")
-        self.assertEqual(fs["args"], ["helloworld"])
+        self.assertEqual(spec.nodename, "sum_nums")
+        self.assertEqual(spec.funcname, "sum_nums")
+        self.assertEqual(spec.args, ["helloworld"])
 
-        self.assertEqual(fs["conditions"]["colonyname"], "colonyname")
-        self.assertEqual(fs["conditions"]["executortype"], "echo_executor")
-        self.assertEqual(fs["conditions"]["executorname"], "exec_name")
+        self.assertEqual(spec.conditions.colonyname, "colonyname")
+        self.assertEqual(spec.conditions.executortype, "echo_executor")
+        self.assertEqual(spec.conditions.executornames[0], "exec_name")
 
-        self.assertEqual(fs["priority"], 0)
-        self.assertEqual(fs["maxexectime"], 10)
-        self.assertEqual(fs["maxretries"], 3)
-        self.assertEqual(fs["maxwaittime"], 100)
+        self.assertEqual(spec.priority, 0)
+        self.assertEqual(spec.maxexectime, 10)
+        self.assertEqual(spec.maxretries, 3)
+        self.assertEqual(spec.maxwaittime, 100)
 
-        self.assertEqual(fs["kwargs"], kwargs)
+        self.assertEqual(spec.kwargs, kwargs)


### PR DESCRIPTION
Refactors the SDK to use Python types instead of dicts with the help of pydantic.

Should make the SDK easier to use as you get some help from the type system and more robust by providing some validation of payloads without having to hit the Colonies server. Using the types internally also makes the code easier to read and update IMO.

The func_spec -helper method has been left in to remain (mostly) compatible with existing code and not having to rewrite all examples from scratch. However, it will now return a typed FuncSpec object rather than a dict. It also provides some utility when passing python code to an executor.

If we merge this the documentation on https://colonyos.github.io/documentation/ will also need updating but I decided to hold off on doing that until getting some feedback from you regarding the proposed solution. I can fix that as well if you think this is a good direction for the design of the SDK going forward.