### PR TITLE
Make kwargs validation less strict and fix some warnings

### DIFF
--- a/model.py
+++ b/model.py
@@ -34,7 +34,7 @@ class FuncSpec(BaseModel):
     nodename: str = ""
     funcname: str = ""
     args: List[str | int] = []
-    kwargs: Dict[str, str] | None = {}
+    kwargs: Dict[str, str | List[str]] | None = {}
     priority: int = 0
     maxwaittime: int = 0
     maxexectime: int = 0

--- a/model.py
+++ b/model.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from typing import List, Dict, Optional
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 class Gpu(BaseModel):
     name: str = ""
@@ -152,7 +152,7 @@ class File(BaseModel):
     ref: Reference = Field(..., alias="ref")
     added: Optional[datetime] = Field(None, alias="added")
 
-    @validator('label')
+    @field_validator('label')
     def ensure_single_slash(cls, v):
         if not v.startswith('/'):
             v = '/' + v

--- a/pycolonies.py
+++ b/pycolonies.py
@@ -716,7 +716,7 @@ class Colonies:
     
     def download_file(self, colonyname, prvkey,  dst=None, label=None, fileid=None, filename=None, latest=True):
         if fileid is not None and filename is not None:
-            raise ValueError("Both 'fileid' and 'name' cannot be set at the same time. Please provide only one.")
+            raise ValueError("Both 'fileid' and 'filename' cannot be set at the same time. Please provide only one.")
         
         access_key = os.getenv("AWS_S3_ACCESSKEY")
         secret_key = os.getenv("AWS_S3_SECRETKEY")
@@ -770,7 +770,7 @@ class Colonies:
 
     def download_data(self, colonyname, prvkey, label=None, fileid=None, filename=None, latest=True):
         if fileid is not None and filename is not None:
-            raise ValueError("Both 'fileid' and 'name' cannot be set at the same time. Please provide only one.")
+            raise ValueError("Both 'fileid' and 'filename' cannot be set at the same time. Please provide only one.")
         
         access_key = os.getenv("AWS_S3_ACCESSKEY")
         secret_key = os.getenv("AWS_S3_SECRETKEY")

--- a/pycolonies.py
+++ b/pycolonies.py
@@ -689,7 +689,7 @@ class Colonies:
     
     def get_file(self, colonyname, prvkey, label=None, fileid=None, filename=None, latest=True):
         if fileid is not None and filename is not None:
-            raise ValueError("Both 'fileid' and 'name' cannot be set at the same time. Please provide only one.")
+            raise ValueError("Both 'fileid' and 'filename' cannot be set at the same time. Please provide only one.")
         
         msg = {
             "msgtype": "getfilemsg",
@@ -769,7 +769,7 @@ class Colonies:
             raise e
 
     def download_data(self, colonyname, prvkey, label=None, fileid=None, filename=None, latest=True):
-        if fileid is not None and name is not None:
+        if fileid is not None and filename is not None:
             raise ValueError("Both 'fileid' and 'name' cannot be set at the same time. Please provide only one.")
         
         access_key = os.getenv("AWS_S3_ACCESSKEY")

--- a/test/colonies_test.py
+++ b/test/colonies_test.py
@@ -661,5 +661,11 @@ class TestColonies(unittest.TestCase):
 
         self.colonies.del_colony(colonyname, self.server_prv)
 
+    def test_download_file_raise_value_error_for_conflicting_parameters(self):
+        with self.assertRaises(ValueError) as err:
+            self.colonies.download_file("test", "prvkey", fileid="123", filename="filename")
+        
+        self.assertEqual("Both 'fileid' and 'name' cannot be set at the same time. Please provide only one.", str(err.exception))
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/colonies_test.py
+++ b/test/colonies_test.py
@@ -8,13 +8,14 @@ from pycolonies import Colonies
 from model import FuncSpec, Conditions, Workflow
 import os
 
+test_colony_host = os.environ.get('TEST_COLONY_HOST', 'localhost')
+test_colony_prvkey = os.environ.get('TEST_COLONY_PRVKEY', 'fcc79953d8a751bf41db661592dc34d30004b1a651ffa0725b03ac227641499d')
+
 class TestColonies(unittest.TestCase):
     def setUp(self):
-        self.colonies = Colonies("localhost", 50080, tls=False, native_crypto=False)
+        self.colonies = Colonies(test_colony_host, 50080, tls=False, native_crypto=False)
         self.crypto = Crypto(native=False)
-        self.server_prv = (
-            "fcc79953d8a751bf41db661592dc34d30004b1a651ffa0725b03ac227641499d"
-        )
+        self.server_prv = test_colony_prvkey
 
     def ran_prefix(self):
         return "".join(random.choices(string.ascii_uppercase + string.digits, k=10))

--- a/test/colonies_test.py
+++ b/test/colonies_test.py
@@ -665,7 +665,13 @@ class TestColonies(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             self.colonies.download_file("test", "prvkey", fileid="123", filename="filename")
         
-        self.assertEqual("Both 'fileid' and 'name' cannot be set at the same time. Please provide only one.", str(err.exception))
+        self.assertEqual("Both 'fileid' and 'filename' cannot be set at the same time. Please provide only one.", str(err.exception))
+
+    def test_download_data_raise_value_error_for_conflicting_parameters(self):
+        with self.assertRaises(ValueError) as err:
+            self.colonies.download_data("test", "prvkey", fileid="123", filename="filename")
+        
+        self.assertEqual("Both 'fileid' and 'filename' cannot be set at the same time. Please provide only one.", str(err.exception))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/func_spec_test.py
+++ b/test/func_spec_test.py
@@ -8,7 +8,8 @@ class TestFuncSpec(unittest.TestCase):
 
         kwargs = {
             "one": "1",
-            "two": "2"
+            "two": "2",
+            "three": ["3", "4"]
         }
 
         spec = func_spec(

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -1,0 +1,21 @@
+import unittest
+
+from pycolonies import File, Reference, S3Object
+
+
+class TestModel(unittest.TestCase):
+    def test_file_ensures_single_slash(self):
+        object = S3Object(server="server", port=123, tls=False, accesskey="key", secretkey="secret",
+                          region="region", encryptionkey="enckey", encryptionalg="alg", object="object", bucket="bucket")
+
+        reference = Reference(protocol="proto", s3object=object)
+
+        file_with_auto_appended_slash = File(fileid="id", colonyname="testcolony", label="filelabel",
+                    name="filename", size=100, sequencenr=1, checksum="cheksum", checksumalg="alg", ref=reference)
+        
+        assert "/filelabel" == file_with_auto_appended_slash.label
+
+        file_with_single_leading_slash = file_with_auto_appended_slash = File(fileid="id", colonyname="testcolony", label="///filelabel",
+                    name="filename", size=100, sequencenr=1, checksum="cheksum", checksumalg="alg", ref=reference)
+
+        assert "/filelabel" == file_with_single_leading_slash.label


### PR DESCRIPTION
This fixes some small issues:
- The field validation for kwargs in FuncSpec prohibited developers from passing arrays of strings as value which is supported by the server and a useful feature.
- The field validator for the label field in File used a pydantic v1 style validator which is deprecated.
- The download_data and download_file methods had a typo in the validation code asserting that not both filename and fileid are provided.
- The integration tests in colonies_test.py had hard-coded hostname and private key for the colonies server making them difficult to run in some environments. The default values can now be overridden through environment variables.